### PR TITLE
Support for custom sender (and signer) for user operations

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,8 @@ import (
 )
 
 type ClientConfig struct {
-	Signer            Signer
+	Sender            *common.Address
+	SenderSigner      Signer
 	EntryPointVersion string
 	RpcURL            *url.URL
 	PaymasterURL      *url.URL
@@ -22,7 +23,8 @@ type UserOperationResult struct {
 }
 
 type Client struct {
-	Signer          Signer
+	Sender          *common.Address
+	SenderSigner    Signer
 	EntryPoint      Entrypoint
 	PaymasterClient *PaymasterClient
 	BundlerClient   *BundlerClient
@@ -30,7 +32,7 @@ type Client struct {
 }
 
 func NewClient(config *ClientConfig) (*Client, error) {
-	if config.Signer == nil || config.PaymasterURL == nil || config.BundlerURL == nil || config.EntryPointVersion != EntryPointVersion07 || config.ChainID == nil {
+	if config.SenderSigner == nil || config.PaymasterURL == nil || config.BundlerURL == nil || config.EntryPointVersion != EntryPointVersion07 || config.ChainID == nil {
 		return nil, errors.New("signer, paymasterURL, bundlerURL, entryPoint, and chainID are required")
 	}
 
@@ -50,7 +52,7 @@ func NewClient(config *ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		Signer:          config.Signer,
+		SenderSigner:    config.SenderSigner,
 		PaymasterClient: paymasterClient,
 		BundlerClient:   bundlerClient,
 		EntryPoint:      entrypoint,
@@ -64,22 +66,25 @@ func (c *Client) Close() {
 	c.EntryPoint.Close()
 }
 
-func (c *Client) SendUserOperation(sender common.Address, callData *[]byte) (*UserOperationResult, error) {
+// GetUserOperationAndHashToSign creates a UserOperation based on the sender and callData, computes its hash and returns both.
+// Allows to create UserOperation with custom sender and then customize the signing process.
+// After adding signature to the returned UserOperation, it can be sent by SendSignedUserOperation
+func (c *Client) GetUserOperationAndHashToSign(sender *common.Address, callData *[]byte) (*UserOperation, *common.Hash, error) {
 	var err error
 	var op UserOperation
 
-	nonce, err := c.EntryPoint.GetNonce(&sender)
+	nonce, err := c.EntryPoint.GetNonce(sender)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	op.Sender = &sender
+	op.Sender = sender
 	op.Nonce = nonce
 	op.CallData = *callData
 
 	gasPrice, err := c.BundlerClient.GetUserOperationGasPrice()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	op.MaxFeePerGas = gasPrice.Standard.MaxFeePerGas
@@ -87,7 +92,7 @@ func (c *Client) SendUserOperation(sender common.Address, callData *[]byte) (*Us
 
 	sponsorResponse, err := c.PaymasterClient.SponsorUserOperation(&op)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	op.Paymaster = sponsorResponse.Paymaster
@@ -100,17 +105,16 @@ func (c *Client) SendUserOperation(sender common.Address, callData *[]byte) (*Us
 
 	opHash, err := c.EntryPoint.GetUserOperationHash(&op)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	signature, err := c.Signer.SignHash(*opHash)
-	if err != nil {
-		return nil, err
-	}
+	return &op, opHash, nil
+}
 
-	op.Signature = signature
-
-	response, err := c.BundlerClient.SendUserOperation(&op)
+// SendSignedUserOperation sends a pre-signed user operation to the bundler.
+// Allows to create UserOperation with different sender and this sender's signature
+func (c *Client) SendSignedUserOperation(signedOp *UserOperation) (*UserOperationResult, error) {
+	response, err := c.BundlerClient.SendUserOperation(signedOp)
 	if err != nil {
 		return nil, err
 	}
@@ -118,4 +122,22 @@ func (c *Client) SendUserOperation(sender common.Address, callData *[]byte) (*Us
 	return &UserOperationResult{
 		TxHash: response,
 	}, nil
+}
+
+// SendUserOperation creates and sends a signed user operation using the provided call data.
+// Sender of the user operation is the client's Sender and the signer is SenderSigner
+func (c *Client) SendUserOperation(callData *[]byte) (*UserOperationResult, error) {
+	op, opHash, err := c.GetUserOperationAndHashToSign(c.Sender, callData)
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := c.SenderSigner.SignHash(*opHash)
+	if err != nil {
+		return nil, err
+	}
+
+	op.Signature = signature
+
+	return c.SendSignedUserOperation(op)
 }

--- a/client.go
+++ b/client.go
@@ -32,8 +32,8 @@ type Client struct {
 }
 
 func NewClient(config *ClientConfig) (*Client, error) {
-	if config.SenderSigner == nil || config.PaymasterURL == nil || config.BundlerURL == nil || config.EntryPointVersion != EntryPointVersion07 || config.ChainID == nil {
-		return nil, errors.New("signer, paymasterURL, bundlerURL, entryPoint, and chainID are required")
+	if config.Sender == nil || config.SenderSigner == nil || config.PaymasterURL == nil || config.BundlerURL == nil || config.EntryPointVersion != EntryPointVersion07 || config.ChainID == nil {
+		return nil, errors.New("sender, senderSigner, paymasterURL, bundlerURL, entryPointVersion, and chainID are required")
 	}
 
 	entrypoint, err := NewEntrypoint07(config.RpcURL, config.ChainID)


### PR DESCRIPTION
- default user operation sender and signer configured when creating the client
- ability to get user operation and its hash with different sender for external signing
- readme and small docs